### PR TITLE
vlc-Makefile: Copy alsa and pulseaudio libraries to /app/lib

### DIFF
--- a/vlc-Makefile
+++ b/vlc-Makefile
@@ -6,3 +6,5 @@ install:
 	# install vlc.sh /app/bin/vlc
 	# cp /usr/bin/ar /app/bin
 	# cp /usr/lib/libbfd-*.so /app/lib
+	find /usr/lib/*/ -name "*.so" -type f -exec ln -s {} /app/lib 2> /dev/null \;
+	find /app/lib/*/ -name "*.so" -type f -exec ln -s {} /app/lib 2> /dev/null \;


### PR DESCRIPTION
Due to lack of mlocated or another service seaching for libraries according to /etc/ld.so.conf, processes inside flatpak are unable to load libraries which are in deeper directories inside /usr/lib or /app/lib.