### PR TITLE
Bump zlib to 1.2.11

### DIFF
--- a/org.videolan.App.json
+++ b/org.videolan.App.json
@@ -829,8 +829,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "http://zlib.net/zlib-1.2.8.tar.gz",
-          "sha256": "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d"
+          "url": "http://zlib.net/zlib-1.2.11.tar.xz",
+          "sha256": "4ff941449631ace0d4d203e3483be9dbc9da454084111f97ea0a2114e19bf066"
         }
       ]
     },


### PR DESCRIPTION
zlib.net doesn't provide the tarballs for the old releases, hence bumping the version.